### PR TITLE
0009082 - :ambulance: Prévoir un stockage de compose_data en dehors de la session

### DIFF
--- a/config/config.inc.php.sample
+++ b/config/config.inc.php.sample
@@ -18,7 +18,6 @@
 */
 
 $config = [];
-
 // Database connection string (DSN) for read+write operations
 // Format (compatible with PEAR MDB2): db_provider://user:password@host/database
 // Currently supported db_providers: mysql, pgsql, sqlite, mssql, sqlsrv, oracle
@@ -64,3 +63,9 @@ $config['plugins'] = [
 
 // skin name: folder from skins/
 $config['skin'] = 'elastic';
+// PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
+// Backend to use for compose_data storage. 
+//Can either be 'session' (default), 'redis', 'memcache', 'apc', or 'db'
+$config['compose_data_storage'] = 'session';
+// Lifetime of compose data storage. Possible units: s, m, h, d, w
+$config['compose_data_storage_ttl'] = '8h'; 

--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -22,7 +22,6 @@ $config = [];
 // ----------------------------------
 // SQL DATABASE
 // ----------------------------------
-
 // Database connection string (DSN) for read+write operations
 // Format (compatible with PEAR MDB2): db_provider://user:password@host/database
 // Currently supported db_providers: mysql, pgsql, sqlite, mssql, sqlsrv, oracle
@@ -1486,3 +1485,9 @@ $config['message_show_email'] = false;
 // 0 - Reply-All always
 // 1 - Reply-List if mailing list is detected
 $config['reply_all_mode'] = 0;
+// PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
+// Backend to use for compose_data storage. 
+//Can either be 'session' (default), 'redis', 'memcache', 'apc', or 'db'
+$config['compose_data_storage'] = 'session';
+// Lifetime of compose data storage. Possible units: s, m, h, d, w
+$config['compose_data_storage_ttl'] = '8h'; 

--- a/program/actions/mail/compose.php
+++ b/program/actions/mail/compose.php
@@ -1779,12 +1779,15 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
 
     // PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
     /**
-     * Retrieve compose data by ID from the configured storage backend.
+     * Handles storage actions (get, set, remove) for compose data using the configured backend.
      *
-     * @param string $id The compose data identifier
-     * @return mixed The compose data if found, or null otherwise
+     * @param string $id   The compose data identifier
+     * @param int    $type The action type: 0 = get, 1 = set, 2 = remove
+     * @param mixed  $data Optional data to store (used for set)
+     * @return mixed|null  The compose data for get, or null for set/remove
+     * @throws Exception   If an invalid storage type or action is provided
      */
-    public static function get_compose_data($id) {
+    private static function _compose_storage_action($id, $type, $data = null) {
         $compose_id = null;
 
         $key = "compose_data_$id";
@@ -1793,24 +1796,80 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
 
         switch ($storage_type) {
             case 'session':
-                $compose_id = $_SESSION[$key];
+                switch ($type) {
+                    case 0:
+                        $compose_id = $_SESSION[$key];
+                        break;
+
+                    case 1:
+                        $_SESSION[$key] = $data;
+                        break;
+
+                    case 2:
+                        $rcmail->session->remove($key);
+                        break;
+
+                    default:
+                        throw new Exception("Invalide storage type");
+                        
+                }
                 break;
 
             case 'apc':
-            case 'db';
+            case 'db':
             case 'redis':
             case 'memcache':
                 $ttl = $rcmail->config->get('compose_data_ttl', '8h');
-                $compose_id = $rcmail->get_cache('compose_data', $storage_type, $ttl)->get($key);
+                $compose_id = call_user_func([$rcmail->get_cache('compose_data', $storage_type, $ttl), self::_get_cache_function($type)], $key, $data);
                 break;
             
             default:
-                $plugin = $rcmail->plugins->exec_hook('get_compose_id', ['id' => $id, 'storage_type' => $storage_type]);
+                $plugin = $rcmail->plugins->exec_hook(self::_get_cache_function($type).'_compose_id', ['id' => $id, 'storage_type' => $storage_type, 'data' => $data]);
                 if (isset($plugin['compose_id'])) $compose_id = $plugin['compose_id'];
                 break;
         }
 
         return $compose_id;
+    }
+
+    /**
+     * Returns the cache function name corresponding to the action type.
+     *
+     * @param int $type The action type: 0 = get, 1 = set, 2 = remove
+     * @return string   The cache function name ('get', 'set', or 'remove')
+     * @throws Exception If an invalid action type is provided
+     */
+    private static function _get_cache_function($type) : string {
+        $cache_function = null;
+        switch ($type) {
+            case 0:
+                $cache_function = 'get';
+                break;
+
+            case 1:
+                $cache_function = 'set';
+                break;
+
+            case 2:
+                $cache_function = 'remove';
+                break;
+
+            default:
+                throw new Exception("Invalide storage type");
+                
+        }
+
+        return $cache_function;
+    }
+
+    /**
+     * Retrieve compose data by ID from the configured storage backend.
+     *
+     * @param string $id The compose data identifier
+     * @return mixed The compose data if found, or null otherwise
+     */
+    public static function get_compose_data($id) {
+        return self::_compose_storage_action($id, 0);
     }
 
     /**
@@ -1821,27 +1880,7 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
      * @return mixed The stored compose data
      */
     public static function set_compose_data($id, $data) {
-        $key = "compose_data_$id";
-        $rcmail = rcmail::get_instance();
-        $storage_type = $rcmail->config->get('compose_data_storage', 'session');
-
-        switch ($storage_type) {
-            case 'session':
-                $_SESSION[$key] = $data;
-                break;
-
-            case 'apc':
-            case 'db';
-            case 'redis':
-            case 'memcache':
-                $ttl = $rcmail->config->get('compose_data_ttl', '8h');
-                $rcmail->get_cache('compose_data', $storage_type, $ttl)->set($key, $data);
-                break;
-            
-            default:
-                $rcmail->plugins->exec_hook('set_compose_id', ['id' => $id, 'storage_type' => $storage_type]);
-                break;
-        }
+        self::_compose_storage_action($id, 1, $data);
 
         return $data;
     }
@@ -1852,28 +1891,8 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
      * @param string $id The compose data identifier
      * @return void
      */
-    public static function remove_compose_data($id) {
-        $key = "compose_data_$id";
-        $rcmail = rcmail::get_instance();
-        $storage_type = $rcmail->config->get('compose_data_storage', 'session');
-
-        switch ($storage_type) {
-            case 'session':
-                $rcmail->session->remove($key);
-                break;
-
-            case 'apc':
-            case 'db';
-            case 'redis':
-            case 'memcache':
-                $ttl = $rcmail->config->get('compose_data_ttl', '8h');
-                $rcmail->get_cache('compose_data', $ttl)->remove($key);
-                break;
-            
-            default:
-                $rcmail->plugins->exec_hook('remove_compose_id', ['id' => $id, 'storage_type' => $storage_type]);
-                break;
-        }
+    public static function remove_compose_data($id) : void {
+        self::_compose_storage_action($id, 2);
     }
     // END PAMELA
 }

--- a/program/actions/mail/compose.php
+++ b/program/actions/mail/compose.php
@@ -39,8 +39,10 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
         self::$COMPOSE_ID = rcube_utils::get_input_string('_id', rcube_utils::INPUT_GET);
         self::$COMPOSE    = null;
 
-        if (self::$COMPOSE_ID && !empty($_SESSION['compose_data_' . self::$COMPOSE_ID])) {
-            self::$COMPOSE =& $_SESSION['compose_data_' . self::$COMPOSE_ID];
+        // PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
+        if (self::$COMPOSE_ID && !empty(self::get_compose_data(self::$COMPOSE_ID))) {
+            // PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
+            self::$COMPOSE =& self::get_compose_data(self::$COMPOSE_ID);
         }
 
         // give replicated session storage some time to synchronize
@@ -48,8 +50,10 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
         while (self::$COMPOSE_ID && !is_array(self::$COMPOSE) && $rcmail->db->is_replicated() && $retries++ < 5) {
             usleep(500000);
             $rcmail->session->reload();
-            if ($_SESSION['compose_data_' . self::$COMPOSE_ID]) {
-                self::$COMPOSE =& $_SESSION['compose_data_' . self::$COMPOSE_ID];
+            // PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
+            if (self::get_compose_data(self::$COMPOSE_ID)) {
+                // PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
+                self::$COMPOSE =& self::get_compose_data(self::$COMPOSE_ID);
             }
         }
 
@@ -71,15 +75,18 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
             self::$COMPOSE_ID = uniqid(mt_rand());
             $params     = rcube_utils::request2param(rcube_utils::INPUT_GET, 'task|action', true);
 
-            $_SESSION['compose_data_' . self::$COMPOSE_ID] = [
+            $compose_data = [
                 'id'      => self::$COMPOSE_ID,
                 'param'   => $params,
                 'mailbox' => isset($params['mbox']) && strlen($params['mbox'])
                     ? $params['mbox'] : $rcmail->storage->get_folder(),
             ];
 
-            self::$COMPOSE =& $_SESSION['compose_data_' . self::$COMPOSE_ID];
+            // PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
+            self::$COMPOSE =& $compose_data;
             self::process_compose_params(self::$COMPOSE);
+            // PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
+            self::set_compose_data(self::$COMPOSE_ID, self::$COMPOSE);
 
             // check if folder for saving sent messages exists and is subscribed (#1486802)
             if (!empty(self::$COMPOSE['param']['sent_mbox'])) {
@@ -355,6 +362,9 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
         $rcmail->output->include_script('publickey.js');
 
         self::spellchecker_init();
+
+        // PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
+        self::set_compose_data(self::$COMPOSE_ID, self::$COMPOSE);
 
         $rcmail->output->send('compose');
     }
@@ -1766,4 +1776,104 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
 
         return rtrim($out, "\n");
     }
+
+    // PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
+    /**
+     * Retrieve compose data by ID from the configured storage backend.
+     *
+     * @param string $id The compose data identifier
+     * @return mixed The compose data if found, or null otherwise
+     */
+    public static function get_compose_data($id) {
+        $compose_id = null;
+
+        $key = "compose_data_$id";
+        $rcmail = rcmail::get_instance();
+        $storage_type = $rcmail->config->get('compose_data_storage', 'session');
+
+        switch ($storage_type) {
+            case 'session':
+                $compose_id = $_SESSION[$key];
+                break;
+
+            case 'apc':
+            case 'db';
+            case 'redis':
+            case 'memcache':
+                $ttl = $rcmail->config->get('compose_data_ttl', '8h');
+                $compose_id = $rcmail->get_cache('compose_data', $storage_type, $ttl)->get($key);
+                break;
+            
+            default:
+                $plugin = $rcmail->plugins->exec_hook('get_compose_id', ['id' => $id, 'storage_type' => $storage_type]);
+                if (isset($plugin['compose_id'])) $compose_id = $plugin['compose_id'];
+                break;
+        }
+
+        return $compose_id;
+    }
+
+    /**
+     * Store compose data by ID in the configured storage backend.
+     *
+     * @param string $id   The compose data identifier
+     * @param mixed  $data The compose data to store
+     * @return mixed The stored compose data
+     */
+    public static function set_compose_data($id, $data) {
+        $key = "compose_data_$id";
+        $rcmail = rcmail::get_instance();
+        $storage_type = $rcmail->config->get('compose_data_storage', 'session');
+
+        switch ($storage_type) {
+            case 'session':
+                $_SESSION[$key] = $data;
+                break;
+
+            case 'apc':
+            case 'db';
+            case 'redis':
+            case 'memcache':
+                $ttl = $rcmail->config->get('compose_data_ttl', '8h');
+                $rcmail->get_cache('compose_data', $storage_type, $ttl)->set($key, $data);
+                break;
+            
+            default:
+                $rcmail->plugins->exec_hook('set_compose_id', ['id' => $id, 'storage_type' => $storage_type]);
+                break;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Remove compose data by ID from the configured storage backend.
+     *
+     * @param string $id The compose data identifier
+     * @return void
+     */
+    public static function remove_compose_data($id) {
+        $key = "compose_data_$id";
+        $rcmail = rcmail::get_instance();
+        $storage_type = $rcmail->config->get('compose_data_storage', 'session');
+
+        switch ($storage_type) {
+            case 'session':
+                $rcmail->session->remove($key);
+                break;
+
+            case 'apc':
+            case 'db';
+            case 'redis':
+            case 'memcache':
+                $ttl = $rcmail->config->get('compose_data_ttl', '8h');
+                $rcmail->get_cache('compose_data', $ttl)->remove($key);
+                break;
+            
+            default:
+                $rcmail->plugins->exec_hook('remove_compose_id', ['id' => $id, 'storage_type' => $storage_type]);
+                break;
+        }
+    }
+    // END PAMELA
 }

--- a/program/actions/mail/compose.php
+++ b/program/actions/mail/compose.php
@@ -42,7 +42,7 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
         // PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
         if (self::$COMPOSE_ID && !empty(self::get_compose_data(self::$COMPOSE_ID))) {
             // PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
-            self::$COMPOSE =& self::get_compose_data(self::$COMPOSE_ID);
+            self::$COMPOSE = self::get_compose_data(self::$COMPOSE_ID);
         }
 
         // give replicated session storage some time to synchronize
@@ -53,7 +53,7 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
             // PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
             if (self::get_compose_data(self::$COMPOSE_ID)) {
                 // PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
-                self::$COMPOSE =& self::get_compose_data(self::$COMPOSE_ID);
+                self::$COMPOSE = self::get_compose_data(self::$COMPOSE_ID);
             }
         }
 
@@ -75,15 +75,13 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
             self::$COMPOSE_ID = uniqid(mt_rand());
             $params     = rcube_utils::request2param(rcube_utils::INPUT_GET, 'task|action', true);
 
-            $compose_data = [
+            // PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
+            self::$COMPOSE = [
                 'id'      => self::$COMPOSE_ID,
                 'param'   => $params,
                 'mailbox' => isset($params['mbox']) && strlen($params['mbox'])
                     ? $params['mbox'] : $rcmail->storage->get_folder(),
             ];
-
-            // PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
-            self::$COMPOSE =& $compose_data;
             self::process_compose_params(self::$COMPOSE);
             // PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
             self::set_compose_data(self::$COMPOSE_ID, self::$COMPOSE);
@@ -1788,17 +1786,16 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
      * @throws Exception   If an invalid storage type or action is provided
      */
     private static function _compose_storage_action($id, $type, $data = null) {
-        $compose_id = null;
-
-        $key = "compose_data_$id";
+        $compose_data = null;
         $rcmail = rcmail::get_instance();
         $storage_type = $rcmail->config->get('compose_data_storage', 'session');
 
         switch ($storage_type) {
             case 'session':
+                $key = "compose_data_$id";
                 switch ($type) {
                     case 0:
-                        $compose_id = $_SESSION[$key];
+                        $compose_data = $_SESSION[$key];
                         break;
 
                     case 1:
@@ -1820,16 +1817,16 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
             case 'redis':
             case 'memcache':
                 $ttl = $rcmail->config->get('compose_data_ttl', '8h');
-                $compose_id = call_user_func([$rcmail->get_cache('compose_data', $storage_type, $ttl), self::_get_cache_function($type)], $key, $data);
+                $compose_data = call_user_func([$rcmail->get_cache('compose_data', $storage_type, $ttl), self::_get_cache_function($type)], $id, $data); //$id instead of $key for avoid redundant name in cache
                 break;
             
             default:
-                $plugin = $rcmail->plugins->exec_hook(self::_get_cache_function($type).'_compose_id', ['id' => $id, 'storage_type' => $storage_type, 'data' => $data]);
-                if (isset($plugin['compose_id'])) $compose_id = $plugin['compose_id'];
+                $plugin = $rcmail->plugins->exec_hook(self::_get_cache_function($type).'_compose_data', ['id' => $id, 'storage_type' => $storage_type, 'data' => $data, 'compose_data' => null]);
+                if (isset($plugin['compose_data'])) $compose_data = $plugin['compose_data'];
                 break;
         }
 
-        return $compose_id;
+        return $compose_data;
     }
 
     /**

--- a/program/actions/mail/send.php
+++ b/program/actions/mail/send.php
@@ -35,7 +35,7 @@ class rcmail_action_mail_send extends rcmail_action
 
         $COMPOSE_ID = rcube_utils::get_input_string('_id', rcube_utils::INPUT_GPC);
         // PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
-        $COMPOSE    =& rcmail_action_mail_compose::get_compose_data($COMPOSE_ID);
+        $COMPOSE    = rcmail_action_mail_compose::get_compose_data($COMPOSE_ID);
 
         // Sanity checks
         if (!isset($COMPOSE['id'])) {

--- a/program/actions/mail/send.php
+++ b/program/actions/mail/send.php
@@ -34,7 +34,8 @@ class rcmail_action_mail_send extends rcmail_action
         $rcmail->output->framed = true;
 
         $COMPOSE_ID = rcube_utils::get_input_string('_id', rcube_utils::INPUT_GPC);
-        $COMPOSE    =& $_SESSION['compose_data_'.$COMPOSE_ID];
+        // PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
+        $COMPOSE    =& rcmail_action_mail_compose::get_compose_data($COMPOSE_ID);
 
         // Sanity checks
         if (!isset($COMPOSE['id'])) {
@@ -343,7 +344,8 @@ class rcmail_action_mail_send extends rcmail_action
             }
             else {
                 $rcmail->plugins->exec_hook('attachments_cleanup', ['group' => $COMPOSE_ID]);
-                $rcmail->session->remove('compose_data_' . $COMPOSE_ID);
+                // PAMELA - Pouvoir sauvegarder le compose_data autre part qu'en session
+                rcmail_action_mail_compose::remove_compose_data($COMPOSE_ID);
                 $_SESSION['last_compose_session'] = $COMPOSE_ID;
 
                 $rcmail->output->command('remove_compose_data', $COMPOSE_ID);


### PR DESCRIPTION
>D'après les tests, l'enregistrement des données de composition en session pose un problème.  
>Il faut donc prévoir une mécanique qui stockerait les données de compose_data ailleurs.