### PR TITLE
0008829 - ✨ Faire un message de notification lorsque qu'une redirection Sieve vers l'extérieur est positionnée

### DIFF
--- a/plugins/managesieve/managesieve.php
+++ b/plugins/managesieve/managesieve.php
@@ -265,13 +265,14 @@ class managesieve extends rcube_plugin
         }
 
         $engine = $this->get_engine();
-        $engine->save();
 
         // PAMEL - MANTIS 0008829: Faire un message de notification lorsque qu'une redirection Sieve vers l'extérieur est positionnée
         rcmail::get_instance()->plugins->exec_hook('managesieve_save_after', ['plugin' => $this, 'engine' => $engine]);
 
         // PAMELA - MANTIS 8807: Faire une trace de log lorsque d'une règle Sieve (Filtres) est enregistrée
         mel_logs::get_instance()->log(mel_logs::INFO, "[Sieve] manage_sieve_save()");
+
+        $engine->save();
     }
 
     /**

--- a/plugins/managesieve/managesieve.php
+++ b/plugins/managesieve/managesieve.php
@@ -266,7 +266,7 @@ class managesieve extends rcube_plugin
 
         $engine = $this->get_engine();
 
-        // PAMEL - MANTIS 0008829: Faire un message de notification lorsque qu'une redirection Sieve vers l'extérieur est positionnée
+        // PAMELA - MANTIS 0008829: Faire un message de notification lorsque qu'une redirection Sieve vers l'extérieur est positionnée
         rcmail::get_instance()->plugins->exec_hook('managesieve_save_after', ['plugin' => $this, 'engine' => $engine]);
 
         // PAMELA - MANTIS 8807: Faire une trace de log lorsque d'une règle Sieve (Filtres) est enregistrée

--- a/plugins/managesieve/managesieve.php
+++ b/plugins/managesieve/managesieve.php
@@ -266,6 +266,10 @@ class managesieve extends rcube_plugin
 
         $engine = $this->get_engine();
         $engine->save();
+
+        // PAMEL - MANTIS 0008829: Faire un message de notification lorsque qu'une redirection Sieve vers l'extérieur est positionnée
+        rcmail::get_instance()->plugins->exec_hook('managesieve_save_after', ['plugin' => $this, 'engine' => $engine]);
+
         // PAMELA - MANTIS 8807: Faire une trace de log lorsque d'une règle Sieve (Filtres) est enregistrée
         mel_logs::get_instance()->log(mel_logs::INFO, "[Sieve] manage_sieve_save()");
     }


### PR DESCRIPTION
>Si une redirection Sieve est positionnée vers des adresses "extérieures", il faut envoyer un message d'alerte avec les mêmes destinataires que les messages d'alerte de grillage de comptes

