### PR TITLE
0009040 - :bug: En mode mobile, lorsqu'on est sur la navigation tel, la fiche du contact le texte Téléphone mobile ne s'affiche pas entièrement

### DIFF
--- a/program/localization/fr_FR/labels.inc
+++ b/program/localization/fr_FR/labels.inc
@@ -405,7 +405,8 @@ $labels['qrcode'] = 'Code QR';
 $labels['typehome'] = 'Domicile';
 $labels['typework'] = 'Travail';
 $labels['typeother'] = 'Autre';
-$labels['typemobile'] = 'Téléphone mobile';
+//PAMELA
+$labels['typemobile'] = 'Mobile';
 $labels['typemain'] = 'Principale';
 $labels['typehomefax'] = 'Fax personnel';
 $labels['typeworkfax'] = 'Fax professionnel';


### PR DESCRIPTION
En allant sur Annuaire > atteindre la fiche du contact après la recherche depuis le téléphone ( affichage portrait) on a un bout du texte qui ne s'affiche pas  Résultat attendu: avoir le même affichage adaptatif reprenant Téléphone mobile: xx xx xx xx xx