### PR TITLE
0009317 - ✨ Problème de déconnexion mobile

### DIFF
--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -477,7 +477,7 @@ class rcube
 
         // set session cookie lifetime so it never expires (#5961)
         // PAMELA - 0009317: Problème de déconnexion mobile
-        ini_set('session.cookie_lifetime', $lifetime ? $lifetime * 10 : 0);
+        ini_set('session.cookie_lifetime', $lifetime ? $lifetime * 100 : 0);
         ini_set('session.cookie_secure', $is_secure);
         ini_set('session.name', $sess_name ?: 'roundcube_sessid');
         ini_set('session.use_cookies', 1);

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -476,7 +476,8 @@ class rcube
         }
 
         // set session cookie lifetime so it never expires (#5961)
-        ini_set('session.cookie_lifetime', 0);
+        // PAMELA - 0009317: Problème de déconnexion mobile
+        ini_set('session.cookie_lifetime', $lifetime ? $lifetime * 10 : 0);
         ini_set('session.cookie_secure', $is_secure);
         ini_set('session.name', $sess_name ?: 'roundcube_sessid');
         ini_set('session.use_cookies', 1);

--- a/program/lib/Roundcube/rcube_session.php
+++ b/program/lib/Roundcube/rcube_session.php
@@ -715,7 +715,7 @@ abstract class rcube_session
     {
         $this->cookie = $this->_mkcookie($this->now);
         // PAMELA - 0009317: Problème de déconnexion mobile
-        rcube_utils::setcookie($this->cookiename, $this->cookie, $this->lifetime ? time() + $this->lifetime * 10 : 0);
+        rcube_utils::setcookie($this->cookiename, $this->cookie, $this->lifetime ? time() + $this->lifetime * 100 : 0);
         $_COOKIE[$this->cookiename] = $this->cookie;
     }
 

--- a/program/lib/Roundcube/rcube_session.php
+++ b/program/lib/Roundcube/rcube_session.php
@@ -714,7 +714,8 @@ abstract class rcube_session
     public function set_auth_cookie()
     {
         $this->cookie = $this->_mkcookie($this->now);
-        rcube_utils::setcookie($this->cookiename, $this->cookie, 0);
+        // PAMELA - 0009317: Problème de déconnexion mobile
+        rcube_utils::setcookie($this->cookiename, $this->cookie, $this->lifetime ? time() + $this->lifetime * 10 : 0);
         $_COOKIE[$this->cookiename] = $this->cookie;
     }
 


### PR DESCRIPTION
Fix mantis 0009317: Problème de déconnexion mobile

Passer les deux cookies d'un mode session illimité à une expiration dans 100x la durée de session pour éviter que les navigateurs mobiles les nettoies

```
[session.cookie_lifetime](https://www.php.net/manual/en/session.configuration.php#ini.session.cookie-lifetime)=0

0 possesses a particular meaning. It informs browsers not to store the cookie to permanent storage. Therefore, when the browser is terminated, the session ID cookie is deleted immediately. If developers set this other than 0, it may allow other users to use the session ID. Most applications should use "0" for this.

If an auto-login feature is required, developers must implement their own secure auto-login feature. Do not use long life session IDs for this. More information can be found above in the relevant section.
```