### PR TITLE
0009565 - :arrow_up: Maj de sécurité roundcube 1.6.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog Roundcube Webmail
 
+## Release 1.6.18
+
+- Password: Fix fatal error "Class 'Zxcvbn' not found" (#10274)
+- Fix out-of-bounds string reads on truncated compressed-RTF in the TNEF decoder (#10269)
+- Security: Add basic validation for content proxied by the css proxy
+- Security: Fix SSRF bypass via specific local address URLs using 100.64.0.0/10 and fe80::/10 nets
+- Security: Fix SSRF filter bypass via various forms of nip.io/sslip.io hostnames evading is_local_url() check
+- Security: Fix remote content blocking bypass via unclosed url() in a FuncIRI attribute
+- Security: Fix LDAP filter injection via unescaped %u/%fu/%d substitution into the `search_filter`
+- Security: Fix arbitrary Sieve script injection via a filter rule name bypassing `managesieve_disabled_actions`
+- Security: Fix RCE via `cmd_learn` driver of markasjunk plugin
+- Security: Fix IMAP command injection via mail search and LITERAL+ byte-count desynchronization
+- Security: Fix password's modoboa driver leak of an authentication token to a user-controlled host
+- Security: Fix stored XSS in "Add to address book" action
+- Security: Fix HTML/CSS sanitization bypass via SVG animate `by` attribute
+
 ## Release 1.6.17
 
 - Enigma: Support automatic public key lookup (import) using HKP v1 protocol (#5314)

--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 /**
  +-------------------------------------------------------------------------+
  | Roundcube Webmail IMAP Client                                           |
- | Version 1.6.17                                                           |
+ | Version 1.6.18                                                           |
  |                                                                         |
  | Copyright (C) The Roundcube Dev Team                                    |
  |                                                                         |

--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_script.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_script.php
@@ -240,7 +240,7 @@ class rcube_sieve_script
 
             // header
             if (!empty($rule['name']) && strlen($rule['name'])) {
-                $script .= '# rule:[' . $rule['name'] . "]\r\n";
+                $script .= '# rule:[' . preg_replace('/[\r\n]+/', ' ', $rule['name']) . "]\r\n";
             }
 
             // constraints expressions

--- a/plugins/markasjunk/drivers/cmd_learn.php
+++ b/plugins/markasjunk/drivers/cmd_learn.php
@@ -56,21 +56,24 @@ class markasjunk_cmd_learn
 
         // backwards compatibility %xds removed in markasjunk v1.12
         $command = str_replace('%xds', '%h:x-dspam-signature', $command);
-        $command = str_replace('%u', escapeshellarg($_SESSION['username']), $command);
-        $command = str_replace('%l', escapeshellarg($rcube->user->get_username('local')), $command);
-        $command = str_replace('%d', escapeshellarg($rcube->user->get_username('domain')), $command);
+
+        $vars = [
+            '%u' => escapeshellarg($rcube->get_user_name()),
+            '%l' => escapeshellarg($rcube->user->get_username('local')),
+            '%d' => escapeshellarg($rcube->user->get_username('domain')),
+        ];
+
         if (strpos($command, '%i') !== false) {
             $identity = $rcube->user->get_identity();
-            $command  = str_replace('%i', escapeshellarg($identity['email']), $command);
+            $vars['%i'] = escapeshellarg($identity['email']);
         }
 
         foreach ($uids as $uid) {
-            // reset command for next message
-            $tmp_command = $command;
+            $replace = $vars;
 
             if (strpos($tmp_command, '%s') !== false) {
-                $message     = new rcube_message($uid);
-                $tmp_command = str_replace('%s', escapeshellarg($message->sender['mailto']), $tmp_command);
+                $message = new rcube_message($uid);
+                $replace['%s'] = escapeshellarg($message->sender['mailto']);
             }
 
             if (!empty($header_names)) {
@@ -86,7 +89,7 @@ class markasjunk_cmd_learn
                     }
 
                     if (!empty($val)) {
-                        $tmp_command = str_replace('%h:' . $header, escapeshellarg($val), $tmp_command);
+                        $replace['%h:' . $header] = escapeshellarg($val);
                     }
                     else {
                         if ($debug) {
@@ -101,9 +104,10 @@ class markasjunk_cmd_learn
             if (strpos($command, '%f') !== false) {
                 $tmpfname = tempnam($temp_dir, 'rcmSALearn');
                 file_put_contents($tmpfname, $rcube->storage->get_raw_body($uid));
-                $tmp_command = str_replace('%f', escapeshellarg($tmpfname), $tmp_command);
+                $replace['%f'] = escapeshellarg($tmpfname);
             }
 
+            $tmp_command = strtr($command, $replace);
             $output = shell_exec($tmp_command);
 
             if ($debug) {

--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -456,7 +456,16 @@ $config['password_kpasswd_cmd'] = '/usr/bin/kpasswd';
 
 // Modoboa Driver options
 // ---------------------
-// put token number from Modoboa server
+// API host. Supported replacement variables:
+// %h - user's IMAP hostname
+// %n - hostname ($_SERVER['SERVER_NAME'])
+// %t - hostname without the first part
+// %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
+// %z - IMAP domain (IMAP hostname without the first part)
+// Note: For security reasons replacement variables are not available if $config['imap_host'] is empty.
+$config['password_modoboa_api_host'] = '%h';
+
+// Modoboa API authentication token
 $config['password_modoboa_api_token'] = '';
 
 

--- a/plugins/password/drivers/modoboa.php
+++ b/plugins/password/drivers/modoboa.php
@@ -35,19 +35,23 @@
 
 class rcube_modoboa_password
 {
-    function save($curpass, $passwd)
+    function save($curpass, $passwd, $username)
     {
         // Init config access
-        $rcmail           = rcmail::get_instance();
-        $ModoboaToken     = $rcmail->config->get('password_modoboa_api_token');
-        $RoudCubeUsername = $_SESSION['username'];
-        $IMAPhost         = $_SESSION['imap_host'];
+        $rcmail = rcmail::get_instance();
+        $token = $rcmail->config->get('password_modoboa_api_token');
+        $host = $rcmail->config->get('password_modoboa_api_host');
+
+        // We don't allow replacement variables when the host name(s) come from the user
+        if (!empty($rcmail->config->get('imap_host'))) {
+            $host = rcube_utils::parse_host($host);
+        }
 
         // Call GET to fetch values from modoboa server
         $curl = curl_init();
 
         curl_setopt_array($curl, [
-            CURLOPT_URL            => "https://" . $IMAPhost . "/api/v1/accounts/?search=" . urlencode($RoudCubeUsername),
+            CURLOPT_URL            => "https://" . $host . "/api/v1/accounts/?search=" . urlencode($username),
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_ENCODING       => "",
             CURLOPT_MAXREDIRS      => 10,
@@ -55,7 +59,7 @@ class rcube_modoboa_password
             CURLOPT_HTTP_VERSION   => CURL_HTTP_VERSION_1_1,
             CURLOPT_CUSTOMREQUEST  => "GET",
             CURLOPT_HTTPHEADER     => [
-                "Authorization: Token " . $ModoboaToken,
+                "Authorization: Token " . $token,
                 "Cache-Control: no-cache",
                 "Content-Type: application/json"
             ],
@@ -91,7 +95,7 @@ class rcube_modoboa_password
         $curl = curl_init();
 
         curl_setopt_array($curl, [
-            CURLOPT_URL            => "https://" . $IMAPhost . "/api/v1/accounts/" . $userid . "/",
+            CURLOPT_URL => "https://" . $host . "/api/v1/accounts/" . $userid . "/",
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_ENCODING       => "",
             CURLOPT_MAXREDIRS      => 10,
@@ -100,7 +104,7 @@ class rcube_modoboa_password
             CURLOPT_CUSTOMREQUEST  => "PUT",
             CURLOPT_POSTFIELDS     => "" . $encoded . "",
             CURLOPT_HTTPHEADER     => [
-                "Authorization: Token " . $ModoboaToken,
+                "Authorization: Token " . $token,
                 "Cache-Control: no-cache",
                 "Content-Type: application/json"
             ],

--- a/plugins/password/drivers/zxcvbn.php
+++ b/plugins/password/drivers/zxcvbn.php
@@ -1,5 +1,7 @@
 <?php
 
+use ZxcvbnPhp\Zxcvbn;
+
 /**
  * Zxcvb Password Strength Driver
  *

--- a/program/actions/mail/addcontact.php
+++ b/program/actions/mail/addcontact.php
@@ -90,7 +90,7 @@ class rcmail_action_mail_addcontact extends rcmail_action
             }
         }
         else {
-            $rcmail->output->show_message($error ?: 'errorsavingcontact', 'error', null, false);
+            $rcmail->output->show_message($error ? rcmail::Q($error) : 'errorsavingcontact', 'error', null, false);
         }
 
         $rcmail->output->send();

--- a/program/actions/mail/search.php
+++ b/program/actions/mail/search.php
@@ -244,6 +244,8 @@ class rcmail_action_mail_search extends rcmail_action_mail_index
         $srch      = null;
         $supported = ['subject', 'from', 'to', 'cc', 'bcc'];
 
+        $str = preg_replace('/[\r\n]+/', ' ', $str);
+
         // Check the search string for type of search
         if (preg_match("/^(from|to|reply-to|cc|bcc|subject):.*/i", $str, $m)) {
             list(, $srch) = explode(":", $str);

--- a/program/actions/utils/modcss.php
+++ b/program/actions/utils/modcss.php
@@ -65,9 +65,8 @@ class rcmail_action_utils_modcss extends rcmail_action
 
         $container_id = preg_replace('/[^a-z0-9]/i', '', $cid);
         $css_prefix   = preg_replace('/[^a-z0-9]/i', '', $prefix);
-        $ctype_regexp = '~^text/(css|plain)~i';
 
-        if ($source !== false && $ctype && preg_match($ctype_regexp, $ctype)) {
+        if ($source !== false && self::is_valid_css($source, $ctype)) {
             $rcmail->output->sendExit(
                 rcube_utils::mod_css_styles($source, $container_id, false, $css_prefix),
                 ['Content-Type: text/css']
@@ -75,5 +74,21 @@ class rcmail_action_utils_modcss extends rcmail_action
         }
 
         $rcmail->output->sendExitError(404, "Invalid response returned by server");
+    }
+
+
+    /**
+     * Do basic response validation
+     */
+    private static function is_valid_css(string $source, $ctype): bool
+    {
+        // Because we can't block all requests to local services we have to be strict
+        // on what we proxy to the browser. Here we check if we deal with css or not.
+
+        return preg_match('~^text/(css|plain)~i', (string) $ctype)
+            && !preg_match('~^[{<]~', $source) // exclude json and html
+            && strpos($source, '{')
+            && strpos($source, '}')
+            && strpos($source, ':');
     }
 }

--- a/program/lib/Roundcube/rcube_ldap.php
+++ b/program/lib/Roundcube/rcube_ldap.php
@@ -349,11 +349,12 @@ class rcube_ldap extends rcube_addressbook
 
                 // Get the pieces needed for variable replacement.
                 if ($fu = ($rcube->get_user_email() ?: ($conf['username'] ?? null))) {
+                    $fu = rcube_ldap_generic::quote_string($fu);
                     list($u, $d) = explode('@', $fu);
                 }
                 else {
                     $u = '';
-                    $d = $this->mail_domain;
+                    $d = rcube_ldap_generic::quote_string($this->mail_domain);
                 }
 
                 $dc = 'dc='.strtr($d, ['.' => ',dc=']); // hierarchal domain string
@@ -2226,7 +2227,7 @@ class rcube_ldap extends rcube_addressbook
         }
 
         $base_dn     = $this->groups_base_dn;
-        $contact_dn  = self::dn_decode($contact_id);
+        $contact_dn = rcube_ldap_generic::quote_string(self::dn_decode($contact_id));
         $name_attr   = $this->prop['groups']['name_attr'] ?: 'cn';
         $member_attr = $this->get_group_member_attr();
         $add_filter  = '';

--- a/program/lib/Roundcube/rcube_tnef_decoder.php
+++ b/program/lib/Roundcube/rcube_tnef_decoder.php
@@ -547,6 +547,12 @@ class rcube_tnef_decoder
         }
 
         while ($out < ($size + $length_preload)) {
+            // Bail out if the input is exhausted to avoid out-of-bounds reads
+            // on truncated/malformed payloads.
+            if ($in >= $max_len) {
+                break;
+            }
+
             if (($flag_count++ % 8) == 0) {
                 $flags = ord($data[$in++]);
             }
@@ -555,6 +561,11 @@ class rcube_tnef_decoder
             }
 
             if (($flags & 1) != 0) {
+                // The back-reference branch reads two more bytes.
+                if ($in + 1 >= $max_len) {
+                    break;
+                }
+
                 $offset = ord($data[$in++]);
                 $length = ord($data[$in++]);
                 $offset = ($offset << 4) | ($length >> 4);
@@ -573,12 +584,13 @@ class rcube_tnef_decoder
                 }
             }
             else {
+                // The literal branch reads one more byte.
+                if ($in >= $max_len) {
+                    break;
+                }
+
                 $uncomp .= $data[$in++];
                 ++$out;
-            }
-
-            if ($in >= $max_len) {
-                break;
             }
         }
 

--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -445,7 +445,14 @@ class rcube_utils
             $host = preg_replace('/^[0:]*:ffff:/i', '', $host);
 
             if (preg_match('/([0-9a-f.-]+)\.(nip|sslip)\.io$/i', $host, $matches)) {
-                $host = trim($matches[1], '-.');
+                $host = $matches[1];
+                if (preg_match('/([0-9]{1,3}([.-][0-9]{1,3}){3})$/', $host, $m)) {
+                    $host = str_replace('-', '.', $m[1]); // IPv4
+                } elseif (preg_match('/^([0-9a-f]{8})$/i', $host, $m)) {
+                    $host = long2ip(base_convert($m[1], 16, 10)); // Hexadecimal
+                } else {
+                    $host = str_replace('-', ':', $host); // IPv6
+                }
             }
 
             // TODO: This is pretty fast, but a single message can contain multiple links
@@ -458,8 +465,10 @@ class rcube_utils
                     '172.16.0.0/12',  // RFC1918
                     '192.168.0.0/16', // RFC1918
                     '169.254.0.0/16', // link-local / cloud metadata
+                    '100.64.0.0/10', // RFC6598: Shared Address Space (carrier-grade NAT)
                     '::1/128',
                     'fc00::/7',
+                    'fe80::/10', // IPv6 link-local
                 ];
 
                 foreach ($nets as $net) {

--- a/program/lib/Roundcube/rcube_washtml.php
+++ b/program/lib/Roundcube/rcube_washtml.php
@@ -293,7 +293,7 @@ class rcube_washtml
             $key   = strtolower($name);
             $value = $attr->nodeValue;
 
-            if ($key == 'style' || ($key == 'values' && self::attribute_value($node, 'attributename', '/^style$/i'))) {
+            if ($key == 'style' || (in_array($key, ['by', 'values']) && self::attribute_value($node, 'attributename', '/^style$/i'))) {
                 $style = '';
                 if ($value === '' || ($style = $this->wash_style($value))) {
                     // replace double quotes to prevent syntax error and XSS issues (#1490227)
@@ -324,7 +324,7 @@ class rcube_washtml
                 }
                 else if ($this->is_funciri_attribute($node->nodeName, $key)) {
                     if (preg_match('/^[a-z:]*url\(/i', $value)) {
-                        if (preg_match('/^([a-z:]*url)\(\s*[\'"]?([^\'"\)]*)[\'"]?\s*\)/iu', $value, $match)) {
+                        if (preg_match('/^([a-z:]*url)\(\s*[\'"]?([^\'"\)]*)[\'"]?\s*\)?/iu', $value, $match)) {
                             if ($url = $this->wash_uri($match[2])) {
                                 $result .= ' ' . $attr->nodeName . '="' . $match[1]
                                     . '(' . htmlspecialchars($url, ENT_QUOTES, $this->config['charset']) . ')'


### PR DESCRIPTION
This is a security update to the version 1.6 of Roundcube Webmail.
It provides fixes to recently reported security vulnerabilities:

    Add basic validation for content proxied by the css proxy
    Fix SSRF bypass via specific local address URLs using 100.64.0.0/10 and fe80::/10 nets, reported by Dmytro Ivanenko
    Fix SSRF filter bypass via various forms of nip.io/sslip.io hostnames evading is_local_url() check, reported by Milan Hoppe
    Fix remote content blocking bypass via unclosed url() in a FuncIRI attribute, reported by Milan Hoppe
    Fix LDAP filter injection via unescaped %u/%fu/%d substitution into the search_filter, reported by Milan Hoppe
    Fix arbitrary Sieve script injection via a filter rule name bypassing managesieve_disabled_actions, reported by Milan Hoppe
    Fix RCE via cmd_learn driver of markasjunk plugin, reported by nept1337
    Fix IMAP command injection via mail search and LITERAL+ byte-count desynchronization, reported by Zach Hanley of Horizon3.ai
    Fix password's modoboa driver leak of an authentication token to a user-controlled host, reported by meifukun
    Fix stored XSS in "Add to address book" action, reported by Paulos Yibelo from pwn.ai
    Fix HTML/CSS sanitization bypass via SVG animate by attribute, reported by vectrain

This version is considered stable and we recommend to update all productive installations of Roundcube with it. Please do backup your data before updating!
CHANGELOG

    Password: Fix fatal error "Class 'Zxcvbn' not found" (#10274)
    Fix out-of-bounds string reads on truncated compressed-RTF in the TNEF decoder (#10269)
    Security: Add basic validation for content proxied by the css proxy
    Security: Fix SSRF bypass via specific local address URLs using 100.64.0.0/10 and fe80::/10 nets
    Security: Fix SSRF filter bypass via various forms of nip.io/sslip.io hostnames evading is_local_url() check
    Security: Fix remote content blocking bypass via unclosed url() in a FuncIRI attribute
    Security: Fix LDAP filter injection via unescaped %u/%fu/%d substitution into the search_filter
    Security: Fix arbitrary Sieve script injection via a filter rule name bypassing managesieve_disabled_actions
    Security: Fix RCE via cmd_learn driver of markasjunk plugin
    Security: Fix IMAP command injection via mail search and LITERAL+ byte-count desynchronization
    Security: Fix password's modoboa driver leak of an authentication token to a user-controlled host
    Security: Fix stored XSS in "Add to address book" action
    Security: Fix HTML/CSS sanitization bypass via SVG animate by attribute


Voir : 
- https://github.com/roundcube/roundcubemail/releases/tag/1.6.18
- https://github.com/roundcube/roundcubemail/compare/1.6.17...1.6.18